### PR TITLE
Fix for wrong patching of main/codec_builtin.c

### DIFF
--- a/alaw16_pass_through.patch
+++ b/alaw16_pass_through.patch
@@ -28,7 +28,7 @@
 +
  static int gsm_samples(struct ast_frame *frame)
 @@ -887,2 +901,4 @@ int ast_codec_builtin_init(void)
- 
+ 	res |= CODEC_REGISTER_AND_CACHE(codec2);
 +	res |= CODEC_REGISTER_AND_CACHE(alaw16);
 +
  	res |= CODEC_REGISTER_AND_CACHE(g723);


### PR DESCRIPTION
This commit fixes an error that causes a change to be made at an incorrect position in main/codec_builtin.c.